### PR TITLE
chore: fix move of repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
     time: "01:17"
   open-pull-requests-limit: 10


### PR DESCRIPTION
The library `canhttp` that was initially in the EVM RPC canister [repository](https://github.com/dfinity/evm-rpc-canister) was moved **as is** from commit [3995dbd](https://github.com/dfinity/evm-rpc-canister/tree/3995dbd3eb3b03a781aaf35453d6757fa6edac47/canhttp) to this repository as commit [d41568a](https://github.com/dfinity/canhttp/commit/d41568adbee2ee3e50d5d68fed27d2fd1a70ab04) while preserving the Git history (using `git filter-repo --subdirectory-filter canhttp` as described [here](https://gist.github.com/trongthanh/2779392)). Additionally, the Git history was rewritten to preserve the links to the original PRs with
```
git filter-repo --message-callback 'return re.sub(br"#(\d{3})", br"dfinity/evm-rpc-canister#\1", message)'
```
so that commit messages like this [one](https://github.com/dfinity/canhttp/commit/d41568adbee2ee3e50d5d68fed27d2fd1a70ab04) that were pointed to PRs such as `#364` are now pointing to `dfinity/evm-rpc-canister#364`.

This broke various things that this PR addresses:

1. Symlinks  for license and notice that were pointing to files outside the moved crate.
2. Re-create a Cargo workspace.
3. Add Github CI pipeline.

