### PR TITLE
ci: ignore `http_canister` with `release-plz`

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -28,3 +28,12 @@ allow_dirty = false
 
 # disallow packaging with uncommitted changes
 publish_allow_dirty = false
+
+[[package]]
+name = "canhttp"
+#git_release_enable = false # enable GitHub releases
+publish = true # enable `cargo publish`
+
+[[package]]
+name = "http_canister"
+release = false # don't process this package


### PR DESCRIPTION
The `http_canister` crate is a test crate that should be ignored by the publish and release pipelines. To address this, add an entry to the `release-plz` configuration to ignore that package. 