### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: 'Run clippy'
         run: cargo clippy --locked --all-targets --all-features -- -D clippy::all
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Cargo doc
         run: |
           cargo doc --workspace --no-deps
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: 'Run unit tests'
         run: cargo test --locked --workspace --exclude http_canister --exclude json_rpc_canister --exclude multi_canister
 
@@ -64,7 +64,7 @@ jobs:
       HTTPBIN_URL: http://localhost
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: 'Build example canisters'
         run: |
@@ -84,7 +84,7 @@ jobs:
           echo "PROXY_CANISTER_WASM_PATH=${PROXY_CANISTER_WASM_PATH}/proxy.wasm" >> $GITHUB_ENV
 
       - name: 'Install PocketIC server'
-        uses: dfinity/pocketic@main
+        uses: dfinity/pocketic@20c33db1aa87cc6ece50857ac632c37acf5e0322 # main
         with:
           pocket-ic-server-version: "12.0.0"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,16 +17,16 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: "Install parse-changelog"
-        uses: taiki-e/install-action@parse-changelog
+        uses: taiki-e/install-action@eb170ab528b4949b44322b05ed3a64beb7bc52f2 # parse-changelog
 
       - name: "Authenticate with crates.io"
         id: auth
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
 
       - name: "Run release-plz"
         id: release-plz
@@ -59,7 +59,7 @@ jobs:
           CHANGELOG="$notes" envsubst < release_notes.md >> ${{ github.workspace }}-RELEASE.txt
 
       - name: "Create Github release"
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           draft: true
           tag_name: ${{ env.RELEASE_TAG}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,9 @@ jobs:
           fetch-depth: 0
 
       - name: "Install parse-changelog"
-        uses: taiki-e/install-action@eb170ab528b4949b44322b05ed3a64beb7bc52f2 # parse-changelog
+        uses: taiki-e/install-action@97a5807a604e12de3a13b52d868ebecaeeea757c # v2.75.4
+        with:
+          tool: parse-changelog@a7723d830fe18d310a89f9692ba0d1ceb069eab7 # v0.6.16
 
       - name: "Authenticate with crates.io"
         id: auth

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Run release-plz


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `dfinity/pocketic@main` -> `dfinity/pocketic@20c33db1aa87cc6ece50857ac632c37acf5e0322 # main`
  - Version: main | Latest: 13.0.0 | Release age: 17d
  - Commit: https://github.com/dfinity/pocketic/commit/20c33db1aa87cc6ece50857ac632c37acf5e0322

- `taiki-e/install-action@parse-changelog` -> `taiki-e/install-action@eb170ab528b4949b44322b05ed3a64beb7bc52f2 # parse-changelog`
  - Version: parse-changelog | Latest: v2.75.4 | Release age: 7d
  - Commit: https://github.com/taiki-e/install-action/commit/eb170ab528b4949b44322b05ed3a64beb7bc52f2
  - Warnings: Latest release v2.75.4 is only 0 day(s) old (< 7 days). Using previous safe release.

- `rust-lang/crates-io-auth-action@v1` -> `rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1`
  - Version: v1 | Latest: v1.0.4 | Release age: 17d
  - Commit: https://github.com/rust-lang/crates-io-auth-action/commit/b7e9a28eded4986ec6b1fa40eeee8f8f165559ec

- `softprops/action-gh-release@v2` -> `softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1`
  - Version: v2.6.1 | Latest: v2.6.1 | Release age: 25d
  - Commit: https://github.com/softprops/action-gh-release/commit/153bb8e04406b158c6c84fc1615b65b24149a1fe


### Files modified

- `.github/workflows/ci.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/release.yml`

### Security warnings

- Latest release v2.75.4 is only 0 day(s) old (< 7 days). Using previous safe release.