### PR TITLE
fix(ci): use semver version for parse-changelog in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: "Install parse-changelog"
         uses: taiki-e/install-action@97a5807a604e12de3a13b52d868ebecaeeea757c # v2.75.4
         with:
-          tool: parse-changelog@a7723d830fe18d310a89f9692ba0d1ceb069eab7 # v0.6.16
+          tool: parse-changelog@0.6.16
 
       - name: "Authenticate with crates.io"
         id: auth


### PR DESCRIPTION
## Summary

The Publish workflow ([run 25732616857](https://github.com/dfinity/canhttp/actions/runs/25732616857/job/75561389431)) fails at the `Install parse-changelog` step with:

```
install-action does not support semver operators: 'a7723d830fe18d310a89f9692ba0d1ceb069eab7'
```

`taiki-e/install-action`'s `tool:` field is parsed internally to look up a release tag — it only accepts semver version specifiers (`0.6.16`, `0.6`, or omitted for latest). The SHA-pinning convention is correct for action `uses:` references (GitHub resolves those) but not for this tool argument.

Fix: `tool: parse-changelog@0.6.16` (the version that was annotated as the intent in the comment).